### PR TITLE
[nrf toup] drivers: nrf_radio_802154: Initialize SWI IRQs once

### DIFF
--- a/drivers/nrf_radio_802154/src/nrf_802154_swi.c
+++ b/drivers/nrf_radio_802154/src/nrf_802154_swi.c
@@ -90,8 +90,14 @@ void nrf_802154_swi_init(void)
 #error NRF_802154_SWI_PRIORITY value out of the allowed range.
 #endif
 
-    nrf_802154_irq_init(SWI_IRQn, NRF_802154_SWI_PRIORITY, swi_irq_handler);
-    nrf_802154_irq_enable(SWI_IRQn);
+    static bool initialized = false;
+
+    if (!initialized)
+    {
+        nrf_802154_irq_init(SWI_IRQn, NRF_802154_SWI_PRIORITY, swi_irq_handler);
+        nrf_802154_irq_enable(SWI_IRQn);
+        initialized = true;
+    }
 }
 
 void SWI_IRQHandler(void)

--- a/drivers/nrf_radio_802154/src/nrf_802154_trx.c
+++ b/drivers/nrf_radio_802154/src/nrf_802154_trx.c
@@ -297,7 +297,10 @@ static void irq_init(void)
 #if !NRF_802154_IRQ_PRIORITY_ALLOWED(NRF_802154_IRQ_PRIORITY)
 #error NRF_802154_IRQ_PRIORITY value out of the allowed range.
 #endif
+
+#if NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
     nrf_802154_irq_init(RADIO_IRQn, NRF_802154_IRQ_PRIORITY, nrf_802154_radio_irq_handler);
+#endif
 }
 
 /** Wait time needed to propagate event through PPI to EGU.


### PR DESCRIPTION
The SWI module in the 802.15.4 driver is used by multiple dependent
modules. Each of the dependent module may initialize the SWI module.
Before this patch, the SWI module configured its IRQs during each
initialization. Now it configures SWI only during the first
initialization.

Signed-off-by: Hubert Miś <hubert.mis@nordicsemi.no>