### PR TITLE
[nrf toup] nrfx_glue: Fix NRFX_PPI_CHANNELS_USED_BY_BT_CTLR definition

### DIFF
--- a/nrfx_glue.h
+++ b/nrfx_glue.h
@@ -240,7 +240,7 @@ void nrfx_busy_wait(u32_t usec_to_wait);
 #define NRFX_PPI_CHANNELS_USED  (NRFX_PPI_CHANNELS_USED_BY_BT_CTLR | \
                                  NRFX_PPI_CHANNELS_USED_BY_PWM_SW)
 
-#if defined(CONFIG_BT_CTLR)
+#if defined(CONFIG_BT_CTLR) && defined(CONFIG_BT_LL_SW_SPLIT)
 extern const u32_t z_bt_ctlr_used_nrf_ppi_channels;
 #define NRFX_PPI_CHANNELS_USED_BY_BT_CTLR   z_bt_ctlr_used_nrf_ppi_channels
 #else


### PR DESCRIPTION
When CONFIG_BT_CTLR is enabled, NRFX_PPI_CHANNELS_USED_BY_BT_CTLR
references a symbol (z_bt_ctlr_used_nrf_ppi_channels) that is defined
in radio.c, a file that is compiled when both CONFIG_BT_CTLR and
CONFIG_BT_LL_SW_SPLIT are enabled. This commit corrects accordingly
the definition of NRFX_PPI_CHANNELS_USED_BY_BT_CTLR, so that it won't
cause an unresolved reference error.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>