### PR TITLE
[nrf toup] drivers: nrf_radio_802154: Update to v2.0.0-2.prealpha

### DIFF
--- a/drivers/nrf_radio_802154/src/nrf_802154.c
+++ b/drivers/nrf_radio_802154/src/nrf_802154.c
@@ -283,7 +283,7 @@ bool nrf_802154_antenna_diversity_rx_mode_set(nrf_802154_sl_ant_div_mode_t mode)
 {
     bool result = false;
 
-#if defined(RADIO_SYNC_EVENT_AVAILABLE)
+#if defined(RADIO_INTENSET_SYNC_Msk)
     result = nrf_802154_sl_ant_div_cfg_mode_set(NRF_802154_SL_ANT_DIV_OP_RX, mode);
 #endif
 
@@ -304,8 +304,8 @@ bool nrf_802154_antenna_diversity_tx_mode_set(nrf_802154_sl_ant_div_mode_t mode)
 {
     bool result = false;
 
-#if defined(RADIO_SYNC_EVENT_AVAILABLE)
-    result = nrf_802154_sl_ant_div_cfg_mode_set(NRF_802154_SL_ANT_DIV_OP_RX, mode);
+#if defined(RADIO_INTENSET_SYNC_Msk)
+    result = nrf_802154_sl_ant_div_cfg_mode_set(NRF_802154_SL_ANT_DIV_OP_TX, mode);
 #endif
 
     if (result)
@@ -366,7 +366,7 @@ nrf_802154_sl_ant_div_antenna_t nrf_802154_antenna_diversity_last_rx_best_antenn
 
 void nrf_802154_antenna_diversity_config_set(const nrf_802154_sl_ant_div_cfg_t * p_cfg)
 {
-#if defined(RADIO_SYNC_EVENT_AVAILABLE)
+#if defined(RADIO_INTENSET_SYNC_Msk)
     nrf_802154_sl_ant_div_cfg_set(p_cfg);
 #endif
 }
@@ -383,7 +383,7 @@ bool nrf_802154_antenna_diversity_init(void)
 
 void nrf_802154_antenna_diversity_timer_irq_handler(void)
 {
-#if defined(RADIO_SYNC_EVENT_AVAILABLE)
+#if defined(RADIO_INTENSET_SYNC_Msk)
     nrf_802154_sl_ant_div_timer_irq_handle();
 #endif
 }

--- a/drivers/nrf_radio_802154/src/nrf_802154_nrfx_addons.h
+++ b/drivers/nrf_radio_802154/src/nrf_802154_nrfx_addons.h
@@ -31,10 +31,6 @@
 
 #include "nrf.h"
 
-#ifdef RADIO_INTENSET_SYNC_Msk
-#define RADIO_SYNC_EVENT_AVAILABLE                         ///< Indicates that RADIO SYNC event is available
-#endif
-
 #if defined (NRF52840_XXAA) || defined(NRF52811_XXAA) || defined(NRF5340_XXAA_NETWORK)
 #define ED_MIN_DBM                   (-92)                 ///< dBm value corresponding to value 0 in the EDSAMPLE register.
 #define ED_RESULT_FACTOR             4                     ///< Factor needed to calculate the ED result based on the data from the RADIO peripheral.


### PR DESCRIPTION
This patch fixes antenna diversity configuration and energy detection-related antenna diversity functionalities in the 802.15.4 driver

KRKNWK-6264
KRKNWK-6270

Signed-off-by: Ciupis, Jedrzej <jedrzej.ciupis@nordicsemi.no>