### PR TITLE
Cherry-pick fixes for NCS 2.5.1

### DIFF
--- a/nrfx/drivers/include/nrfx_qspi.h
+++ b/nrfx/drivers/include/nrfx_qspi.h
@@ -184,12 +184,14 @@ typedef void (*nrfx_qspi_handler_t)(nrfx_qspi_evt_t event, void * p_context);
 /**
  * @brief Function for initializing the QSPI driver instance.
  *
- * This function configures the peripheral and its interrupts, and activates it. During the
- * activation process, the internal clocks are started and the QSPI peripheral tries to read
- * the status byte to read the busy bit. Reading the status byte is done in a simple poll and wait
- * mechanism.
- * If the busy bit is 1, this indicates issues with the external memory device. As a result,
- * @ref nrfx_qspi_init returns NRFX_ERROR_TIMEOUT.
+ * This function configures the peripheral and its interrupts.
+ *
+ * @note The function does not activate the peripheral instance. The activation is done during the first
+ *       transfer after initialization or when calling @ref nrfx_qspi_activate function.
+ *       The activation process starts the internal clocks, and the QSPI peripheral tries to read
+ *       the status byte to check the busy bit. Reading the status byte is done in a simple poll
+ *       and wait mechanism. If the busy bit is set, this indicates issues with the external memory
+ *       device. As a result, transfer functions return @ref NRFX_ERROR_TIMEOUT.
  *
  * In case of issues:
  * - Check the connection.
@@ -206,7 +208,6 @@ typedef void (*nrfx_qspi_handler_t)(nrfx_qspi_evt_t event, void * p_context);
  *          in the Product Specification.
  *
  * @retval NRFX_SUCCESS             Initialization was successful.
- * @retval NRFX_ERROR_TIMEOUT       The peripheral cannot connect with external memory.
  * @retval NRFX_ERROR_INVALID_STATE The driver was already initialized.
  * @retval NRFX_ERROR_INVALID_PARAM The pin configuration was incorrect.
  */
@@ -218,6 +219,9 @@ nrfx_err_t nrfx_qspi_init(nrfx_qspi_config_t const * p_config,
  * @brief Function for reconfiguring the QSPI driver instance.
  *
  * @param[in] p_config Pointer to the structure with the configuration.
+ *
+ * @warning The function deactivates the peripheral instance. The activation is done during the first
+ *          transfer after reconfiguration or when calling @ref nrfx_qspi_activate function.
  *
  * @retval NRFX_SUCCESS             Reconfiguration was successful.
  * @retval NRFX_ERROR_BUSY          The driver is during transaction.
@@ -231,7 +235,31 @@ nrfx_err_t nrfx_qspi_reconfigure(nrfx_qspi_config_t const * p_config);
 void nrfx_qspi_uninit(void);
 
 /**
+ * @brief Function for activating the QSPI driver instance.
+ *
+ * @param[in] wait True if activation is to be in blocking mode, false otherwise.
+ *
+ * @retval NRFX_SUCCESS                   The driver instance has been activated.
+ * @retval NRFX_ERROR_ALREADY_INITIALIZED The driver is already activated.
+ * @retval NRFX_ERROR_TIMEOUT             External memory is busy, or there are connection issues.
+ */
+nrfx_err_t nrfx_qspi_activate(bool wait);
+
+/** @brief Function for deactivating the QSPI driver instance.
+ *
+ * @retval NRFX_SUCCESS    The driver instance has been activated.
+ * @retval NRFX_ERROR_BUSY The driver is during transaction.
+ */
+nrfx_err_t nrfx_qspi_deactivate(void);
+
+/**
  * @brief Function for reading data from the QSPI memory.
+ *
+ * @note If that is the first operation after activation of driver initialization has been triggered,
+ *       the activation process starts the internal clocks and the QSPI peripheral tries to read
+ *       the status byte to check the busy bit. Reading the status byte is done in a simple poll
+ *       and wait mechanism. If the busy bit is set, this indicates that the memory may not be ready yet.
+ *       As a result, the function returns @ref NRFX_ERROR_TIMEOUT.
  *
  * Write, read, and erase operations check memory device busy state before starting the operation.
  * If the memory is busy, the resulting action depends on the mode in which the read operation is used:
@@ -250,6 +278,7 @@ void nrfx_qspi_uninit(void);
  * @retval NRFX_SUCCESS            The operation was successful (blocking mode) or operation
  *                                 was commissioned (handler mode).
  * @retval NRFX_ERROR_BUSY         The driver currently handles another operation.
+ * @retval NRFX_ERROR_TIMEOUT      The external memory is busy, or there are connection issues.
  * @retval NRFX_ERROR_INVALID_ADDR The provided buffer is not placed in the Data RAM region
  *                                 or its address is not aligned to a 32-bit word.
  */
@@ -259,6 +288,8 @@ nrfx_err_t nrfx_qspi_read(void *   p_rx_buffer,
 
 /**
  * @brief Function for writing data to QSPI memory.
+ *
+ * @note Refer to the note for @ref nrfx_qspi_read.
  *
  * Write, read, and erase operations check memory device busy state before starting the operation.
  * If the memory is busy, the resulting action depends on the mode in which the write operation is used:
@@ -281,6 +312,7 @@ nrfx_err_t nrfx_qspi_read(void *   p_rx_buffer,
  * @retval NRFX_SUCCESS            The operation was successful (blocking mode) or operation
  *                                 was commissioned (handler mode).
  * @retval NRFX_ERROR_BUSY         The driver currently handles other operation.
+ * @retval NRFX_ERROR_TIMEOUT      The external memory is busy, or there are connection issues.
  * @retval NRFX_ERROR_INVALID_ADDR The provided buffer is not placed in the Data RAM region
  *                                 or its address is not aligned to a 32-bit word.
  */
@@ -290,6 +322,8 @@ nrfx_err_t nrfx_qspi_write(void const * p_tx_buffer,
 
 /**
  * @brief Function for starting erasing of one memory block - 4KB, 64KB, or the whole chip.
+ *
+ * @note Refer to the note for @ref nrfx_qspi_read.
  *
  * Write, read, and erase operations check memory device busy state before starting the operation.
  * If the memory is busy, the resulting action depends on the mode in which the erase operation is used:
@@ -308,8 +342,9 @@ nrfx_err_t nrfx_qspi_write(void const * p_tx_buffer,
  *
  * @retval NRFX_SUCCESS            The operation was successful (blocking mode) or operation
  *                                 was commissioned (handler mode).
- * @retval NRFX_ERROR_INVALID_ADDR The provided start address is not aligned to a 32-bit word.
  * @retval NRFX_ERROR_BUSY         The driver currently handles another operation.
+ * @retval NRFX_ERROR_TIMEOUT      The external memory is busy, or there are connection issues.
+ * @retval NRFX_ERROR_INVALID_ADDR The provided start address is not aligned to a 32-bit word.
  */
 nrfx_err_t nrfx_qspi_erase(nrf_qspi_erase_len_t length,
                            uint32_t             start_address);
@@ -317,9 +352,12 @@ nrfx_err_t nrfx_qspi_erase(nrf_qspi_erase_len_t length,
 /**
  * @brief Function for starting an erase operation of the whole chip.
  *
- * @retval NRFX_SUCCESS    The operation was successful (blocking mode) or operation
- *                         was commissioned (handler mode).
- * @retval NRFX_ERROR_BUSY The driver currently handles another operation.
+ * @note Refer to the note for @ref nrfx_qspi_read.
+ *
+ * @retval NRFX_SUCCESS       The operation was successful (blocking mode) or
+ *                            commissioned (handler mode).
+ * @retval NRFX_ERROR_BUSY    The driver currently is handling another operation.
+ * @retval NRFX_ERROR_TIMEOUT The external memory is busy, or there are connection issues.
  */
 nrfx_err_t nrfx_qspi_chip_erase(void);
 
@@ -345,12 +383,14 @@ bool nrfx_qspi_xfer_buffered_check(void);
  *        testing WIP (write in progress) bit.
  *
  * @retval NRFX_SUCCESS    The driver and memory are ready to handle a new operation.
- * @retval NRFX_ERROR_BUSY The driver or memory currently handle another operation.
+ * @retval NRFX_ERROR_BUSY The driver currently is handling another operation.
  */
 nrfx_err_t nrfx_qspi_mem_busy_check(void);
 
 /**
  * @brief Function for sending operation code, sending data, and receiving data from the memory device.
+ *
+ * @note Refer to the note for @ref nrfx_qspi_read.
  *
  * Use this function to transfer configuration data to memory and to receive data from memory.
  * Pointers can be addresses from flash memory.
@@ -368,7 +408,7 @@ nrfx_err_t nrfx_qspi_mem_busy_check(void);
  * @param[out] p_rx_buffer Pointer to the array for data to receive. Can be NULL if there is nothing to receive.
  *
  * @retval NRFX_SUCCESS       The operation was successful.
- * @retval NRFX_ERROR_TIMEOUT The external memory is busy or there are connection issues.
+ * @retval NRFX_ERROR_TIMEOUT The external memory is busy, or there are connection issues.
  * @retval NRFX_ERROR_BUSY    The driver currently handles other operation.
  */
 nrfx_err_t nrfx_qspi_cinstr_xfer(nrf_qspi_cinstr_conf_t const * p_config,
@@ -378,6 +418,8 @@ nrfx_err_t nrfx_qspi_cinstr_xfer(nrf_qspi_cinstr_conf_t const * p_config,
 /**
  * @brief Function for sending operation code and data to the memory device with simpler configuration.
  *
+ * @note Refer to the note for @ref nrfx_qspi_read.
+ *
  * Use this function to transfer configuration data to memory and to receive data from memory.
  * This function is a synchronous function and should be used only if necessary.
  *
@@ -385,8 +427,9 @@ nrfx_err_t nrfx_qspi_cinstr_xfer(nrf_qspi_cinstr_conf_t const * p_config,
  * @param[in] length      Length of the data to send and opcode. See @ref nrf_qspi_cinstr_len_t.
  * @param[in] p_tx_buffer Pointer to input data array.
  *
- * @retval NRFX_SUCCESS    The operation was successful.
- * @retval NRFX_ERROR_BUSY The driver currently handles another operation.
+ * @retval NRFX_SUCCESS       The operation was successful.
+ * @retval NRFX_ERROR_BUSY    The driver currently handles another operation.
+ * @retval NRFX_ERROR_TIMEOUT The external memory is busy, or there are connection issues.
  */
 nrfx_err_t nrfx_qspi_cinstr_quick_send(uint8_t               opcode,
                                        nrf_qspi_cinstr_len_t length,
@@ -394,6 +437,8 @@ nrfx_err_t nrfx_qspi_cinstr_quick_send(uint8_t               opcode,
 
 /**
  * @brief Function for starting the custom instruction long frame mode.
+ *
+ * @note Refer to the note for @ref nrfx_qspi_read.
  *
  * The long frame mode is a mechanism that allows for arbitrary byte length custom instructions.
  * Use this function to initiate a custom transaction by sending custom instruction opcode.
@@ -411,12 +456,14 @@ nrfx_err_t nrfx_qspi_cinstr_quick_send(uint8_t               opcode,
  *
  * @retval NRFX_SUCCESS       Operation was successful.
  * @retval NRFX_ERROR_BUSY    Driver currently handles other operation.
- * @retval NRFX_ERROR_TIMEOUT External memory is busy or there are connection issues.
+ * @retval NRFX_ERROR_TIMEOUT The external memory is busy, or there are connection issues.
  */
 nrfx_err_t nrfx_qspi_lfm_start(nrf_qspi_cinstr_conf_t const * p_config);
 
 /**
  * @brief Function for sending and receiving data in the custom instruction long frame mode.
+ *
+ * @note Refer to the note for @ref nrfx_qspi_read.
  *
  * Both specified buffers must be at least @p transfer_length bytes in size.
  *

--- a/nrfx/drivers/src/nrfx_wdt.c
+++ b/nrfx/drivers/src/nrfx_wdt.c
@@ -83,7 +83,6 @@ nrfx_err_t nrfx_wdt_init(nrfx_wdt_t const *        p_instance,
                          nrfx_wdt_config_t const * p_config,
                          nrfx_wdt_event_handler_t  wdt_event_handler)
 {
-    NRFX_ASSERT(p_config);
     nrfx_err_t err_code;
 
     wdt_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];


### PR DESCRIPTION
This PR cherry-picks the commits needed for the NCS 2.5.1 bugfix release. Two commits have been cherry-picked from the nrfx project https://github.com/nrfconnect/nrfx/commit/c636d154a1ff0a0e0ff7ed3eef6955dfcdcf13e2 and https://github.com/nrfconnect/nrfx/commit/35df91b625f7122c82028cdf07983e1eaa45c0dd that are required for NCS 2.5.1 and one commit from hal_nordic https://github.com/zephyrproject-rtos/hal_nordic/commit/56e0b052dff311c2f8eb08c6804e60fc79feb56f that is considered as bugfix and can be included in this NCS release